### PR TITLE
go-vcr: optimizations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/cassette/server_replay.go
+++ b/cassette/server_replay.go
@@ -76,12 +76,7 @@ func headersEqual(expected, actual http.Header) bool {
 		func(v1, v2 []string) bool {
 			slices.Sort(v1)
 			slices.Sort(v2)
-
-			if !slices.Equal(v1, v2) {
-				return false
-			}
-
-			return true
+			return slices.Equal(v1, v2)
 		},
 	)
 }

--- a/recorder/testdata/hello-world.yaml
+++ b/recorder/testdata/hello-world.yaml
@@ -2,6 +2,7 @@
 version: 2
 interactions:
     - id: 0
+      hash: 4dad948ce54e0bffda511861d4578c58aa1437e5887317744a0604b3004352f6
       request:
         proto: HTTP/1.1
         proto_major: 1

--- a/tests/testdata/go-dev.yaml
+++ b/tests/testdata/go-dev.yaml
@@ -2,6 +2,7 @@
 version: 2
 interactions:
     - id: 0
+      hash: 4dad948ce54e0bffda511861d4578c58aa1437e5887317744a0604b3004352f6
       request:
         proto: HTTP/1.1
         proto_major: 1

--- a/tests/testdata/iana-reserved-domains.yaml
+++ b/tests/testdata/iana-reserved-domains.yaml
@@ -2,6 +2,7 @@
 version: 2
 interactions:
     - id: 0
+      hash: cac762106c91fa37a52ffccaeb66895fcd19b5bd5b6858bb76694c0acc3be749
       request:
         proto: HTTP/1.1
         proto_major: 1

--- a/tests/testdata/json-content-type.yaml
+++ b/tests/testdata/json-content-type.yaml
@@ -2,6 +2,7 @@
 version: 2
 interactions:
     - id: 0
+      hash: 8806b4fd924abbf3da6f75a7a672c74451da5031a68bc6e01d166c68e3e3c1a5
       request:
         proto: HTTP/1.1
         proto_major: 1

--- a/tests/testdata/middleware.yaml
+++ b/tests/testdata/middleware.yaml
@@ -2,6 +2,7 @@
 version: 2
 interactions:
     - id: 0
+      hash: a9d35c024679b7b8ee52acbb0d91de64a91d34aa76207a5e14e68d91d704852b
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -31,6 +32,7 @@ interactions:
         code: 200
         duration: 0s
     - id: 1
+      hash: 667a45a9ea090937ee5056157f2450de7ea1acb9f02661493d2f2c1e772d6d53
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -62,6 +64,7 @@ interactions:
         code: 200
         duration: 0s
     - id: 2
+      hash: 9358b92e61c1a10dca87e1d248cdede0bfda70fcfb3b4f2481e89ce989e32650
       request:
         proto: HTTP/1.1
         proto_major: 1
@@ -99,6 +102,7 @@ interactions:
         code: 200
         duration: 0s
     - id: 3
+      hash: 71359bc3334a033e34cc7a3942b0db0ad24a71e985b3e1ab900e33cdda39bf9c
       request:
         proto: HTTP/1.1
         proto_major: 1


### PR DESCRIPTION
This PR provides the following changes:

* `MatcherFunc` and `HasherFunc` had overlapping responsiblities, and I merged into `RequestMatcher` (breaking change). 
* Added a pre-computed hash index. This speeds up loading, as the hash doesn't have to be computed again. I added an automatic migration for vcr files that don't have the hash field.
* Fixed a memory waste by using `yaml.NewDecoder` instead of `io.ReadAll` + `yaml.Unmarshal`.
* Other minor optimizations around memory usage.

